### PR TITLE
Use ERB and SafeYAML to interpolate `jekyll_get` configuration

### DIFF
--- a/jekyll_get.rb
+++ b/jekyll_get.rb
@@ -8,7 +8,9 @@ module Jekyll_Get
     priority :highest
 
     def generate(site)
-      config = site.config['jekyll_get']
+      config = SafeYAML.load(
+        ERB.new(site.config['jekyll_get'].to_yaml).result(binding)
+      )
       if !config
         return
       end


### PR DESCRIPTION
It enables to have following statements in `_config.yml`:

``` yaml
jekyll_get:
  data: attendees
  json: https://event.api/attendees?event_id=148916&api_key=<%= ENV['API_KEY'] %>
  cache: true
```

`API_KEY=foobar bundle exec jekyll serve` will be interpolate at runtime as:

``` yaml
jekyll_get:
  data: attendees
  json: https://event.api/attendees?event_id=148916&api_key=foobar
  cache: true
```

I use `SafeYAML` because this is how jekyll parses its YAML files and because we are the owners of the config files, I guess it is safe enough to use ERB to interpolate Ruby code only and specifically in the `jekyll_get` section.

ping @DirtyF
