### PR TITLE
Load cached files rather than remote json

### DIFF
--- a/_plugins/jekyll_get.rb
+++ b/_plugins/jekyll_get.rb
@@ -16,23 +16,18 @@ module Jekyll_Get
         config = [config]
       end
       config.each do |d|
-        begin
-          target = site.data[d['data']]
+        data_source = (site.config['data_source'] || '_data')
+        path = "#{data_source}/#{d['data']}.json"
+        if d['cache'] && File.exists?(path)
+          source = JSON.load(File.open(path))
+        else
           source = JSON.load(open(d['json']))
-          if target
-            HashJoiner.deep_merge target, source
-          else
-            site.data[d['data']] = source
+        end
+        site.data[d['data']] = source
+        if d['cache']
+          open(path, 'wb') do |file|
+            file << JSON.generate(site.data[d['data']])
           end
-          if d['cache']
-            data_source = (site.config['data_source'] || '_data')
-            path = "#{data_source}/#{d['data']}.json"
-            open(path, 'wb') do |file|
-              file << JSON.generate(site.data[d['data']])
-            end
-          end
-        rescue
-          next
         end
       end
     end


### PR DESCRIPTION
Hello from GDS in the UK, and thanks for making this :)

Sharing this as it might be helpful, but I'm not actually a Ruby dev, so it might be a shockingly bad way of doing things.

I've done a couple of things:

1. Removed `hash-linker` as it was causing problems with my data files, and it's redundant after;
2. Modified the cache to act more like I expected the cache to work: that is, to load files from the local directory, not the remote URL if it exists. To clear the cache, remove the files.

This change works for me, and might be useful to others too.

